### PR TITLE
Change stream health check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.38.0
+
+- Revert change stream health to pre 0.37.0 where `field` is used to determine an
+  issue with change stream event processing.
+- Simplify some code.
+- Add support for sort order (asc, desc) on initial scan.
+
 # 0.37.0
 
 - Emit `cursorError` when an error occurs when calling `hasNext`. Useful for debugging
@@ -7,7 +14,7 @@
   removed since determining a failed health check relies on a delayed check of a
   Redis key and not a MongoDB query.
 - Type parameter on `initSync` to allow for extending the event emitter. Useful for downstream
-libraries like `mongo2mongo` and `mongo2elastic`.
+  libraries like `mongo2mongo` and `mongo2elastic`.
 
 # 0.36.0
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.37.0",
+      "version": "0.38.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.37.0",
+  "version": "0.38.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",
@@ -27,7 +27,8 @@
     "elasticsearch",
     "sql",
     "cratedb",
-    "health"
+    "health",
+    "check"
   ],
   "license": "ISC",
   "engines": {

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -259,8 +259,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       if (scanCompleted) {
         debug(`Initial scan previously completed on %s`, scanCompleted)
         // We're done
-        deferred.done()
-        state.change('started')
+        state.change('stopped')
         return
       }
       // Start the health check

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,8 @@ export interface SortField<T> {
   /** Function to serialize value to string. */
   serialize: (x: T) => string
   deserialize: (x: string) => T
+  /** Sort order: asc or desc. Defaults to asc */
+  order: 'asc' | 'desc'
 }
 
 export interface ScanOptions<T = any> {
@@ -44,7 +46,11 @@ export interface ScanOptions<T = any> {
 export interface ChangeStreamOptions {
   healthCheck?: {
     enabled: boolean
-    /** The max allowed time for a change stream event to be processed. */
+    /** The date field that contains the time the record was last updated */
+    field: string
+    /** How often to run the health check. */
+    interval?: number
+    /** The max allowed time for a modified record to be synced */
     maxSyncDelay?: number
   }
   pipeline?: Document[]


### PR DESCRIPTION
- Revert change stream health check to pre 0.37.0 where `field` is used to determine an
  issue with change stream event processing.
- Simplify some code.
- Add support for custom sort order (asc or desc) on initial scan.