### PR TITLE
Fix dotted path omit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.43.1
+
+- Fix issue where omitting nested paths failed to remove the field from `updateDescription.updatedFields` do to dotted field name.
+
 # 0.43.0
 
 - Optionally pass an array of operation types (`insert`, `update`, ...) to `processChangeStream`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.43.0",
+      "version": "0.43.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.43.0",
+  "version": "0.43.1",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,0 +1,41 @@
+import { test } from 'node:test'
+import assert from 'node:assert'
+import { generatePipelineFromOmit } from './util.js'
+
+test('should generate pipeline from omit', async () => {
+  const pipeline = generatePipelineFromOmit([
+    'documents.agenda.parsedText',
+    'documents.agenda.contentType',
+    'createdAt',
+  ])
+  assert.deepEqual(pipeline, [
+    {
+      $unset: [
+        'fullDocument.documents.agenda.parsedText',
+        'updateDescription.updatedFields.documents.agenda.parsedText',
+        'fullDocument.documents.agenda.contentType',
+        'updateDescription.updatedFields.documents.agenda.contentType',
+        'fullDocument.createdAt',
+        'updateDescription.updatedFields.createdAt',
+      ],
+    },
+    {
+      $set: {
+        'updateDescription.updatedFields': {
+          $arrayToObject: {
+            $filter: {
+              input: { $objectToArray: '$updateDescription.updatedFields' },
+              cond: {
+                $regexMatch: {
+                  input: '$$this.k',
+                  regex:
+                    '^(?!documents.agenda.parsedText|documents.agenda.contentType)',
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  ])
+})

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -2,7 +2,21 @@ import { test } from 'node:test'
 import assert from 'node:assert'
 import { generatePipelineFromOmit } from './util.js'
 
-test('should generate pipeline from omit', async () => {
+test('should generate pipeline from omit with no dotted fields', async () => {
+  const pipeline = generatePipelineFromOmit(['documents', 'createdAt'])
+  assert.deepEqual(pipeline, [
+    {
+      $unset: [
+        'fullDocument.documents',
+        'updateDescription.updatedFields.documents',
+        'fullDocument.createdAt',
+        'updateDescription.updatedFields.createdAt',
+      ],
+    },
+  ])
+})
+
+test('should generate pipeline from omit with dotted fields', async () => {
   const pipeline = generatePipelineFromOmit([
     'documents.agenda.parsedText',
     'documents.agenda.contentType',

--- a/src/util.ts
+++ b/src/util.ts
@@ -14,7 +14,7 @@ export const setDefaults = (keys: string[], val: any) => {
   return obj
 }
 
-export const removeDottedPaths = (omit: string[]) => {
+const removeDottedPaths = (omit: string[]) => {
   const dottedFields = omit.filter((x) => x.includes('.'))
   if (dottedFields.length) {
     return {


### PR DESCRIPTION
Fix issue where omitting nested paths failed to remove the field from `updateDescription.updatedFields` do to dotted field name.

Example:

```js
"updateDescription" : {
        "updatedFields" : {
            "documents.agenda.contentType" : "application/pdf",
            "documents.agenda.parsedText" : "Some text here",
            "steps.parse" : "complete",
            "createdAt" : ISODate("2023-11-20T12:11:33.988-0500")
        }
    },
    "fullDocument" : {
        "createdAt" : ISODate("2023-11-20T12:11:33.988-0500"),
        "documents" : {
            "steps" : {
                "parse" : "complete"
            },
            "agenda" : {
                "contentType" : "application/pdf",
                "parsedText" : "Some text here"
            }
        }
    }
```