### PR TITLE
v0.47.0 - Reworked `safelyCheckNext`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# 0.47.0
+
+- Bumped peer dependencies for `mongodb`.
+- Reworked `safelyCheckNext`.
+
 # 0.46.0
 
 - Bumped peer dependencies for `ioredis` and `mongodb`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.46.0",
+      "version": "0.47.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.5",
@@ -32,7 +32,7 @@
       },
       "peerDependencies": {
         "ioredis": ">= 5.4.1",
-        "mongodb": ">= 6.6.1"
+        "mongodb": ">= 6.8.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2076,9 +2076,9 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.6.1.tgz",
-      "integrity": "sha512-FvA9ocQzRzzvhin1HHLrZDEm0gWvnksbiciYrU/0GmET/t/DdDiMJroA7rfDrHM3AInwGVYw2fwAU2oNYUyUEw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
       "peer": true,
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.5",
@@ -4256,9 +4256,9 @@
       }
     },
     "mongodb": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.6.1.tgz",
-      "integrity": "sha512-FvA9ocQzRzzvhin1HHLrZDEm0gWvnksbiciYrU/0GmET/t/DdDiMJroA7rfDrHM3AInwGVYw2fwAU2oNYUyUEw==",
+      "version": "6.8.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.8.0.tgz",
+      "integrity": "sha512-HGQ9NWDle5WvwMnrvUxsFYPd3JEbqD3RgABHBQRuoCEND0qzhsd0iH5ypHsf1eJ+sXmvmyKpP+FLOKY8Il7jMw==",
       "peer": true,
       "requires": {
         "@mongodb-js/saslprep": "^1.1.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.46.0",
+  "version": "0.47.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",
@@ -59,7 +59,7 @@
   },
   "peerDependencies": {
     "ioredis": ">= 5.4.1",
-    "mongodb": ">= 6.6.1"
+    "mongodb": ">= 6.8.0"
   },
   "prettier": {
     "semi": false,

--- a/src/util.ts
+++ b/src/util.ts
@@ -112,33 +112,27 @@ export function when<T, R>(condition: any, fn: (x: T) => R) {
 }
 
 /**
- * Check if the cursor has next without throwing an exception.
+ * Get next record without throwing an exception.
  * Get the last error safely via `getLastError`.
  */
 export const safelyCheckNext = (cursor: Cursor) => {
   let lastError: unknown
 
-  const hasNext = async () => {
+  const getNext = async () => {
     debug('safelyCheckNext called')
     try {
-      // Prevents hasNext from hanging when the cursor is already closed
-      if (cursor.closed) {
-        debug('safelyCheckNext cursor closed')
-        lastError = new Error('cursor closed')
-        return false
-      }
-      return await cursor.hasNext()
+      return await cursor.tryNext()
     } catch (e) {
       debug('safelyCheckNext error: %o', e)
       lastError = e
-      return false
+      return null
     }
   }
 
   const errorExists = () => Boolean(lastError)
   const getLastError = () => lastError
 
-  return { hasNext, errorExists, getLastError }
+  return { getNext, errorExists, getLastError }
 }
 
 const oplogErrorCodeNames = [


### PR DESCRIPTION
Bumping the `mongodb` peer dep to `>= 6.8.0` required a change to `safelyCheckNext`.