### PR TITLE
Fixed regression in `processChangeStream`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.48.0
 
 - Fixed bug where `processChangeStream` exits prematurely.
+- Fixed bug when omitting an updated nested field.
 
 # 0.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 - Fixed bug where `processChangeStream` exits prematurely.
 - Fixed bug when omitting an updated nested field.
+- Omit fields from `updateDescription.removedFields` to prevent downstream issues.
 
 # 0.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.48.0
+
+- Fixed bug where `processChangeStream` exits prematurely.
+
 # 0.47.0
 
 - Bumped peer dependencies for `mongodb`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.47.0",
+      "version": "0.48.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.5",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "lint": "eslint src/**",
     "fmt": "prettier --ignore-path .gitignore --write './'",
     "test": "node --env-file=.env --test --test-force-exit",
-    "test:only": "DEBUG=* node --env-file=.env --test --test-only --test-force-exit"
+    "test:only": "DEBUG=* DEBUG_DEPTH=10 node --env-file=.env --test --test-only --test-force-exit"
   },
   "keywords": [
     "mongodb",
@@ -65,12 +65,8 @@
     "semi": false,
     "singleQuote": true,
     "trailingComma": "es5",
-    "plugins": [
-      "@trivago/prettier-plugin-sort-imports"
-    ],
-    "importOrder": [
-      "^[./]"
-    ],
+    "plugins": ["@trivago/prettier-plugin-sort-imports"],
+    "importOrder": ["^[./]"],
     "importOrderSortSpecifiers": true,
     "importOrderCaseInsensitive": true,
     "importOrderSeparation": true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.47.0",
+  "version": "0.48.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -574,7 +574,7 @@ describe('syncing', () => {
     await changeStream.stop()
   })
 
-  test('change stream should resume properly', async () => {
+  test('change stream should resume after being stopped', async () => {
     const { coll, db } = await getConns()
     const sync = await getSync()
     await initState(sync, db, coll)
@@ -602,7 +602,41 @@ describe('syncing', () => {
     // Resume change stream
     changeStream.start()
     // Wait for all documents to be processed
-    await setTimeout(ms('8s'))
+    await setTimeout(ms('5s'))
+    // All change stream docs were processed
+    assert.equal(processed.length, numDocs)
+    await changeStream.stop()
+  })
+
+  test('change stream should resume after pause in events', async () => {
+    const { coll, db } = await getConns()
+    const sync = await getSync()
+    await initState(sync, db, coll)
+
+    let processed = []
+    // Change stream
+    const processRecords = async (docs: ChangeStreamDocument[]) => {
+      for (const doc of docs) {
+        await setTimeout(8)
+        processed.push(doc)
+      }
+    }
+    const changeStream = await sync.processChangeStream(processRecords)
+    changeStream.start()
+    // Let change stream connect
+    await setTimeout(ms('1s'))
+    // Change all documents
+    coll.updateMany({}, { $set: { createdAt: new Date('2022-01-02') } })
+    // Wait for all documents to be processed
+    await setTimeout(ms('5s'))
+    // All change stream docs were processed
+    assert.equal(processed.length, numDocs)
+    // Reset processed
+    processed = []
+    // Change all documents
+    coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
+    // Wait for all documents to be processed
+    await setTimeout(ms('5s'))
     // All change stream docs were processed
     assert.equal(processed.length, numDocs)
     await changeStream.stop()

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -680,7 +680,7 @@ describe('syncing', () => {
     // Change all documents
     coll.updateMany({}, { $set: { createdAt: new Date('2022-01-02') } })
     // Wait for all documents to be processed
-    await setTimeout(ms('5s'))
+    await setTimeout(ms('6s'))
     // All change stream docs were processed
     assert.equal(processed.length, numDocs)
     // Reset processed
@@ -688,7 +688,7 @@ describe('syncing', () => {
     // Change all documents
     coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
     // Wait for all documents to be processed
-    await setTimeout(ms('5s'))
+    await setTimeout(ms('6s'))
     // All change stream docs were processed
     assert.equal(processed.length, numDocs)
     await changeStream.stop()

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -462,52 +462,59 @@ describe('syncing', () => {
     assert.equal(cursorError, false)
   })
 
-  test('should omit fields from change stream - dotted paths', async () => {
-    const { coll, db } = await getConns()
-    // address.geo is a path prefix relative to the paths being updated below
-    const sync = await getSync({ omit: ['address.city', 'address.geo'] })
-    await initState(sync, db, coll)
+  test(
+    'should omit fields from change stream - dotted paths',
+    { only: true },
+    async () => {
+      const { coll, db } = await getConns()
+      // address.geo is a path prefix relative to the paths being updated below
+      const sync = await getSync({ omit: ['address.city', 'address.geo'] })
+      await initState(sync, db, coll)
 
-    const documents: Document[] = []
-    const processRecords = async (docs: ChangeStreamDocument[]) => {
-      for (const doc of docs) {
-        await setTimeout(5)
-        if (doc.operationType === 'update' && doc.fullDocument) {
-          documents.push(doc)
+      const documents: Document[] = []
+      const processRecords = async (docs: ChangeStreamDocument[]) => {
+        for (const doc of docs) {
+          await setTimeout(5)
+          if (doc.operationType === 'update' && doc.fullDocument) {
+            documents.push(doc)
+          }
         }
       }
-    }
-    const changeStream = await sync.processChangeStream(processRecords)
-    // Start
-    changeStream.start()
-    await setTimeout(ms('1s'))
-    // Update records
-    coll.updateMany(
-      {},
-      {
-        $set: {
-          name: 'unknown',
-          'address.city': 'San Diego',
-          'address.geo.lat': 24,
-          'address.geo.long': 25,
-        },
-      }
-    )
-    // Wait for the change stream events to be processed
-    await setTimeout(ms('2s'))
-    // Assertions
-    assert.equal(documents[0].fullDocument.address.city, undefined)
-    assert.equal(documents[0].fullDocument.address.geo, undefined)
-    const fields = ['address.city', 'address.geo.lat', 'address.geo.long']
-    for (const field of fields) {
-      assert.equal(
-        documents[0].updateDescription.updatedFields[field],
-        undefined
+      const changeStream = await sync.processChangeStream(processRecords)
+      // Start
+      changeStream.start()
+      await setTimeout(ms('1s'))
+      // Update records
+      coll.updateMany(
+        {},
+        {
+          $set: {
+            name: 'unknown',
+            'address.city': 'San Diego',
+            'address.geo.lat': 24,
+          },
+          $unset: {
+            'address.geo.long': '',
+          },
+        }
       )
+      // Wait for the change stream events to be processed
+      await setTimeout(ms('2s'))
+      // Assertions
+      assert.equal(documents[0].fullDocument.address.city, undefined)
+      assert.equal(documents[0].fullDocument.address.geo, undefined)
+      const fields = ['address.city', 'address.geo.lat']
+      for (const field of fields) {
+        assert.equal(
+          documents[0].updateDescription.updatedFields[field],
+          undefined
+        )
+      }
+      assert.deepEqual(documents[0].removedFields, [])
+      // Stop
+      await changeStream.stop()
     }
-    // Stop
-    await changeStream.stop()
-  })
+  )
 
   test('should omit fields from change stream - nested dotted path', async () => {
     const { coll, db } = await getConns()

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -542,7 +542,6 @@ describe('syncing', () => {
     ])
     // Wait for the change stream events to be processed
     await setTimeout(ms('2s'))
-    // console.dir(documents, { depth: 10 })
     // Assertions
     assert.equal(documents[0].fullDocument.address.geo.long, 25)
     assert.equal(documents[0].fullDocument.address.geo.lat, undefined)

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -425,7 +425,7 @@ describe('syncing', () => {
     assert.ok(documents[0].cityState)
   })
 
-  test('should process records via change stream', { only: true }, async () => {
+  test('should process records via change stream', async () => {
     const { coll, db } = await getConns()
     const sync = await getSync()
     await initState(sync, db, coll)

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -50,6 +50,7 @@ const getSync = async (options?: SyncOptions) => {
 
 const genUser = () => ({
   name: faker.person.fullName(),
+  likes: [faker.animal.dog(), faker.animal.cat()],
   address: {
     city: faker.location.city(),
     state: faker.location.state(),
@@ -69,6 +70,12 @@ const schema: JSONSchema = {
   properties: {
     _id: { bsonType: 'objectId' },
     name: { bsonType: 'string' },
+    likes: {
+      bsonType: 'array',
+      items: {
+        bsonType: 'string',
+      },
+    },
     address: {
       bsonType: 'object',
       properties: {
@@ -451,6 +458,7 @@ describe('syncing', () => {
       {
         $set: { createdAt: new Date('2022-01-01') },
         $unset: { 'address.city': '', 'address.geo.lat': '' },
+        $pop: { likes: 1 },
       }
     )
     // Wait for the change stream events to be processed

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -33,7 +33,7 @@ import {
 import {
   generatePipelineFromOmit,
   getCollectionKey,
-  omitFieldForUpdate,
+  omitUpdatedFields,
   removeUnusedFields,
   setDefaults,
   when,
@@ -387,7 +387,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
         // Omit nested fields that are not handled by $unset.
         // For example, if 'a' was omitted then 'a.b.c' should be omitted.
         if (event.operationType === 'update' && omit) {
-          event = omitFieldForUpdate(omit)(event) as ChangeStreamDocument
+          event = omitUpdatedFields(omit, event) as ChangeStreamDocument
         }
         await queue.enqueue(event)
       }

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -33,7 +33,7 @@ import {
 import {
   generatePipelineFromOmit,
   getCollectionKey,
-  omitUpdatedFields,
+  omitFieldsForUpdate,
   removeUnusedFields,
   setDefaults,
   when,
@@ -387,7 +387,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
         // Omit nested fields that are not handled by $unset.
         // For example, if 'a' was omitted then 'a.b.c' should be omitted.
         if (event.operationType === 'update' && omit) {
-          event = omitUpdatedFields(omit, event) as ChangeStreamDocument
+          omitFieldsForUpdate(omit, event)
         }
         await queue.enqueue(event)
       }

--- a/src/safelyCheckNext.ts
+++ b/src/safelyCheckNext.ts
@@ -1,0 +1,42 @@
+import _debug from 'debug'
+
+import type { Cursor } from './types.js'
+
+const debug = _debug('mongochangestream:safelyCheckNext')
+
+/**
+ * Get next record without throwing an exception.
+ * Get the last error safely via `getLastError`.
+ */
+export const safelyCheckNext = (cursor: Cursor) => {
+  let lastError: unknown
+
+  const getNext = async () => {
+    debug('getNext called')
+    try {
+      return await cursor.tryNext()
+    } catch (e) {
+      debug('getNext error: %o', e)
+      lastError = e
+      return null
+    }
+  }
+
+  const hasNext = async () => {
+    debug('hasNext called')
+    try {
+      return await cursor.hasNext()
+    } catch (e) {
+      if (cursor.closed) {
+        debug('hasNext - cursor closed')
+      }
+      lastError = e
+      return false
+    }
+  }
+
+  const errorExists = () => Boolean(lastError)
+  const getLastError = () => lastError
+
+  return { hasNext, getNext, errorExists, getLastError }
+}

--- a/src/safelyCheckNext.ts
+++ b/src/safelyCheckNext.ts
@@ -27,8 +27,9 @@ export const safelyCheckNext = (cursor: Cursor) => {
     try {
       return await cursor.hasNext()
     } catch (e) {
+      debug('hasNext error: %o', e)
       if (cursor.closed) {
-        debug('hasNext - cursor closed')
+        debug('hasNext cursor closed')
       }
       lastError = e
       return false

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -18,44 +18,6 @@ describe('util', () => {
         },
       ])
     })
-
-    test('should generate pipeline from omit with dotted fields', () => {
-      const pipeline = generatePipelineFromOmit([
-        'documents.agenda.parsedText',
-        'documents.agenda.contentType',
-        'createdAt',
-      ])
-      assert.deepEqual(pipeline, [
-        {
-          $unset: [
-            'fullDocument.documents.agenda.parsedText',
-            'updateDescription.updatedFields.documents.agenda.parsedText',
-            'fullDocument.documents.agenda.contentType',
-            'updateDescription.updatedFields.documents.agenda.contentType',
-            'fullDocument.createdAt',
-            'updateDescription.updatedFields.createdAt',
-          ],
-        },
-        {
-          $set: {
-            'updateDescription.updatedFields': {
-              $arrayToObject: {
-                $filter: {
-                  input: { $objectToArray: '$updateDescription.updatedFields' },
-                  cond: {
-                    $regexMatch: {
-                      input: '$$this.k',
-                      regex:
-                        '^(?!documents\\.agenda\\.parsedText|documents\\.agenda\\.contentType)',
-                    },
-                  },
-                },
-              },
-            },
-          },
-        },
-      ])
-    })
   })
   describe('removeUnusedFields', () => {
     test('should remove all unneeded fields', () => {

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert'
 import { describe, test } from 'node:test'
 
-import { generatePipelineFromOmit, removeUnusedFields } from './util.js'
+import {
+  generatePipelineFromOmit,
+  omitFieldsForUpdate,
+  removeUnusedFields,
+} from './util.js'
 
 describe('util', () => {
   describe('generatePipelineFromOmit', () => {
@@ -81,6 +85,114 @@ describe('util', () => {
           },
         },
       })
+    })
+  })
+  describe('omitFieldsForUpdate', () => {
+    test('should remove omitted fields from removedFields - exact', () => {
+      const event: any = {
+        updateDescription: {
+          updatedFields: {},
+          removedFields: ['address.geo.long'],
+          truncatedArrays: [],
+        },
+      }
+      const expected = {
+        updateDescription: {
+          updatedFields: {},
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      omitFieldsForUpdate(['address.geo.long'], event)
+      assert.deepEqual(event.updateDescription, expected.updateDescription)
+    })
+    test('should remove omitted fields from removedFields - prefix', () => {
+      const event: any = {
+        updateDescription: {
+          updatedFields: {},
+          removedFields: ['address.geo.long'],
+          truncatedArrays: [],
+        },
+      }
+      const expected = {
+        updateDescription: {
+          updatedFields: {},
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      omitFieldsForUpdate(['address.geo'], event)
+      assert.deepEqual(event.updateDescription, expected.updateDescription)
+    })
+    test('should remove omitted fields from updatedFields - exact', () => {
+      const event: any = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+            'address.city': 'San Diego',
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      const expected = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      omitFieldsForUpdate(['address.city'], event)
+      assert.deepEqual(event.updateDescription, expected.updateDescription)
+    })
+    test('should remove omitted fields from updatedFields - prefix', () => {
+      const event: any = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+            'address.geo.lat': 24,
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      const expected = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      omitFieldsForUpdate(['address.geo'], event)
+      assert.deepEqual(event.updateDescription, expected.updateDescription)
+    })
+    test('should remove omitted fields from updatedFields - nested', () => {
+      const event: any = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+            'address.geo': { lat: 24, long: 25 },
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      const expected = {
+        updateDescription: {
+          updatedFields: {
+            name: 'unknown',
+            'address.geo': { long: 25 },
+          },
+          removedFields: [],
+          truncatedArrays: [],
+        },
+      }
+      omitFieldsForUpdate(['address.geo.lat'], event)
+      assert.deepEqual(event.updateDescription, expected.updateDescription)
     })
   })
 })

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -104,7 +104,7 @@ describe('util', () => {
         },
       }
       omitFieldsForUpdate(['address.geo.long'], event)
-      assert.deepEqual(event.updateDescription, expected.updateDescription)
+      assert.deepEqual(event, expected)
     })
     test('should remove omitted fields from removedFields - prefix', () => {
       const event: any = {
@@ -122,7 +122,7 @@ describe('util', () => {
         },
       }
       omitFieldsForUpdate(['address.geo'], event)
-      assert.deepEqual(event.updateDescription, expected.updateDescription)
+      assert.deepEqual(event, expected)
     })
     test('should remove omitted fields from updatedFields - exact', () => {
       const event: any = {
@@ -145,7 +145,7 @@ describe('util', () => {
         },
       }
       omitFieldsForUpdate(['address.city'], event)
-      assert.deepEqual(event.updateDescription, expected.updateDescription)
+      assert.deepEqual(event, expected)
     })
     test('should remove omitted fields from updatedFields - prefix', () => {
       const event: any = {
@@ -168,7 +168,7 @@ describe('util', () => {
         },
       }
       omitFieldsForUpdate(['address.geo'], event)
-      assert.deepEqual(event.updateDescription, expected.updateDescription)
+      assert.deepEqual(event, expected)
     })
     test('should remove omitted fields from updatedFields - nested', () => {
       const event: any = {
@@ -192,7 +192,7 @@ describe('util', () => {
         },
       }
       omitFieldsForUpdate(['address.geo.lat'], event)
-      assert.deepEqual(event.updateDescription, expected.updateDescription)
+      assert.deepEqual(event, expected)
     })
   })
 })

--- a/src/util.ts
+++ b/src/util.ts
@@ -35,7 +35,7 @@ export const generatePipelineFromOmit = (omit: string[]) => {
  *   }
  * }
  * ```
- * Therefore, to remove 'a.b' we have to unflatten the `updateFields` object
+ * Therefore, to remove 'a.b' we have to walk the `updateFields` object
  * and unset the omitted paths.
  */
 export const omitFieldsForUpdate = (

--- a/src/util.ts
+++ b/src/util.ts
@@ -42,9 +42,9 @@ export const omitFieldsForUpdate = (
   omittedPaths: string[],
   event: ChangeStreamUpdateDocument
 ) => {
-  const shouldOmit = (testPath: string) =>
-    omittedPaths.includes(testPath) ||
-    omittedPaths.find((path) => testPath.startsWith(`${path}.`))
+  const shouldOmit = (path: string) =>
+    omittedPaths.includes(path) ||
+    omittedPaths.find((omittedPath) => path.startsWith(`${omittedPath}.`))
 
   if (event.updateDescription.updatedFields) {
     map(

--- a/src/util.ts
+++ b/src/util.ts
@@ -43,8 +43,10 @@ export const omitFieldsForUpdate = (
   event: ChangeStreamUpdateDocument
 ) => {
   const shouldOmit = (path: string) =>
-    omittedPaths.includes(path) ||
-    omittedPaths.find((omittedPath) => path.startsWith(`${omittedPath}.`))
+    omittedPaths.find(
+      (omittedPath) =>
+        path === omittedPath || path.startsWith(`${omittedPath}.`)
+    )
 
   if (event.updateDescription.updatedFields) {
     map(

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,8 @@
-import _debug from 'debug'
 import _ from 'lodash/fp.js'
 import { type Collection, MongoServerError } from 'mongodb'
 import { type Node, walkEach } from 'obj-walker'
 
-import type { Cursor, CursorError, JSONSchema } from './types.js'
-
-const debug = _debug('mongochangestream')
+import type { CursorError, JSONSchema } from './types.js'
 
 export const setDefaults = (keys: string[], val: any) => {
   const obj: Record<string, any> = {}
@@ -109,30 +106,6 @@ export function when<T, R>(condition: any, fn: (x: T) => R) {
   return function (x: T) {
     return condition ? fn(x) : x
   }
-}
-
-/**
- * Get next record without throwing an exception.
- * Get the last error safely via `getLastError`.
- */
-export const safelyCheckNext = (cursor: Cursor) => {
-  let lastError: unknown
-
-  const getNext = async () => {
-    debug('safelyCheckNext called')
-    try {
-      return await cursor.tryNext()
-    } catch (e) {
-      debug('safelyCheckNext error: %o', e)
-      lastError = e
-      return null
-    }
-  }
-
-  const errorExists = () => Boolean(lastError)
-  const getLastError = () => lastError
-
-  return { getNext, errorExists, getLastError }
 }
 
 const oplogErrorCodeNames = [


### PR DESCRIPTION
- `hasNext` is required when waiting for long periods of time for the next change stream event.
- Fixed bug when omitting an updated nested field.
- Omit fields from `updateDescription.removedFields` to prevent downstream issues.
