### PR TITLE
Add `documentKey` to pseudo `ChangeStreamInsertDocument` event for in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.53.0
+
+-   Add `documentKey` to pseudo `ChangeStreamInsertDocument` event for initial scan.
+
 # 0.52.0
 
 -   Use `$match` to filter `operationType`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.52.0",
+      "version": "0.53.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -185,7 +185,7 @@ describe('syncing', () => {
     }
     const initialScan = await sync.runInitialScan(processRecords)
     initialScan.start()
-    await setTimeout(500)
+    await setTimeout(1000)
     // Stop twice
     await initialScan.stop()
     await initialScan.stop()

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -152,7 +152,7 @@ describe('syncing', () => {
     }
     const changeStream = await sync.processChangeStream(processRecords)
     changeStream.start()
-    await setTimeout(100)
+    await setTimeout(500)
     // Change documents
     await coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
     // Stop twice

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -152,6 +152,7 @@ describe('syncing', () => {
     }
     const changeStream = await sync.processChangeStream(processRecords)
     changeStream.start()
+    await setTimeout(100)
     // Change documents
     await coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
     // Stop twice

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -37,11 +37,11 @@ import {
   SyncOptions,
 } from './types.js'
 import {
+  docToChangeStreamInsert,
   generatePipelineFromOmit,
   getCollectionKey,
   omitFieldsForUpdate,
   removeUnusedFields,
-  convertScanDoc,
   setDefaults,
   when,
 } from './util.js'
@@ -106,7 +106,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
   }
   const emitStateChange = (change: object) => emit('stateChange', change)
   const pause = pausable(options.maxPauseTime)
-  const scanDocToChangeStream = convertScanDoc(collection)
+  const toChangeStreamInsert = docToChangeStreamInsert(collection)
   /**
    * Determine if the collection should be resynced by checking for the existence
    * of the resync key in Redis.
@@ -268,7 +268,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       // Process documents
       while ((doc = await nextChecker.getNext())) {
         debug('Initial scan doc %O', doc)
-        await queue.enqueue(scanDocToChangeStream(doc))
+        await queue.enqueue(toChangeStreamInsert(doc))
         await pause.maybeBlock()
       }
       // Flush the queue

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -272,7 +272,8 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
           fullDocument: doc,
           operationType: 'insert',
           ns,
-        } as unknown as ChangeStreamInsertDocument
+          documentKey: { _id: doc?._id },
+        } as ChangeStreamInsertDocument
         await queue.enqueue(changeStreamDoc)
         await pause.maybeBlock()
       }

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -208,15 +208,9 @@ describe('util', () => {
     }
     const result = convertScanDoc(collection)(doc)
     assert.deepEqual(result, {
-      fullDocument: {
-        _id: '123',
-        name: 'Joe',
-      },
+      fullDocument: { _id: '123', name: 'Joe' },
       operationType: 'insert',
-      ns: {
-        dbName: 'testdb',
-        collectionName: 'testcoll',
-      },
+      ns: { db: 'testdb', coll: 'testcoll' },
       documentKey: { _id: '123' },
     })
   })

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -1,7 +1,9 @@
+import { Collection } from 'mongodb'
 import assert from 'node:assert'
 import { describe, test } from 'node:test'
 
 import {
+  convertScanDoc,
   generatePipelineFromOmit,
   omitFieldsForUpdate,
   removeUnusedFields,
@@ -193,6 +195,29 @@ describe('util', () => {
       }
       omitFieldsForUpdate(['address.geo.lat'], event)
       assert.deepEqual(event, expected)
+    })
+  })
+  describe('convertScanDoc', () => {
+    const collection = {
+      dbName: 'testdb',
+      collectionName: 'testcoll',
+    } as Collection
+    const doc = {
+      _id: '123',
+      name: 'Joe',
+    }
+    const result = convertScanDoc(collection)(doc)
+    assert.deepEqual(result, {
+      fullDocument: {
+        _id: '123',
+        name: 'Joe',
+      },
+      operationType: 'insert',
+      ns: {
+        dbName: 'testdb',
+        collectionName: 'testcoll',
+      },
+      documentKey: { _id: '123' },
     })
   })
 })

--- a/src/util.test.ts
+++ b/src/util.test.ts
@@ -3,7 +3,7 @@ import assert from 'node:assert'
 import { describe, test } from 'node:test'
 
 import {
-  convertScanDoc,
+  docToChangeStreamInsert,
   generatePipelineFromOmit,
   omitFieldsForUpdate,
   removeUnusedFields,
@@ -197,7 +197,7 @@ describe('util', () => {
       assert.deepEqual(event, expected)
     })
   })
-  describe('convertScanDoc', () => {
+  describe('docToChangeStreamInsert', () => {
     const collection = {
       dbName: 'testdb',
       collectionName: 'testcoll',
@@ -206,7 +206,7 @@ describe('util', () => {
       _id: '123',
       name: 'Joe',
     }
-    const result = convertScanDoc(collection)(doc)
+    const result = docToChangeStreamInsert(collection)(doc)
     assert.deepEqual(result, {
       fullDocument: { _id: '123', name: 'Joe' },
       operationType: 'insert',

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,7 +1,9 @@
 import { set } from 'lodash'
 import {
+  ChangeStreamInsertDocument,
   type ChangeStreamUpdateDocument,
   type Collection,
+  Document,
   MongoServerError,
 } from 'mongodb'
 import { map, type Node, walkEach } from 'obj-walker'
@@ -156,4 +158,18 @@ export const delayed = (fn: (...args: any[]) => void, ms: number) => {
   }
 
   return delayedFn
+}
+
+/**
+ * Convert an initial scan document to a change steam insert event
+ */
+export const convertScanDoc = (collection: Collection) => {
+  const ns = { db: collection.dbName, coll: collection.collectionName }
+  return (doc: Document) =>
+    ({
+      fullDocument: doc,
+      operationType: 'insert',
+      ns,
+      documentKey: { _id: doc?._id },
+    }) as ChangeStreamInsertDocument
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -170,6 +170,6 @@ export const convertScanDoc = (collection: Collection) => {
       fullDocument: doc,
       operationType: 'insert',
       ns,
-      documentKey: { _id: doc?._id },
+      documentKey: { _id: doc._id },
     }) as ChangeStreamInsertDocument
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -161,9 +161,11 @@ export const delayed = (fn: (...args: any[]) => void, ms: number) => {
 }
 
 /**
- * Convert an initial scan document to a change steam insert event
+ * Convert an initial scan document to a change stream insert document
+ * suitable for downstream consumption. Note: not all fields are present,
+ * such as, _id (resume token).
  */
-export const convertScanDoc = (collection: Collection) => {
+export const docToChangeStreamInsert = (collection: Collection) => {
   const ns = { db: collection.dbName, coll: collection.collectionName }
   return (doc: Document) =>
     ({


### PR DESCRIPTION
-  Add `documentKey` to pseudo `ChangeStreamInsertDocument` event for initial scan to fix downstream `mongo2crate` issue that is expecting this to be there.