### PR TITLE
Emit an `error` event when retries are exhausted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.57.0
+
+-   If `processRecords` repeatedly throws an error and all retries are
+    exhausted, mongochangestream will now catch the final error and emit an
+    `error` event.
+
 # 0.56.0
 
 -   Add retry logic to `processRecords`. Downstream libraries should only throw if

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/types.ts
+++ b/src/types.ts
@@ -85,6 +85,7 @@ export interface ChangeOptions {
 // Events
 
 export type Events =
+  | 'error'
   | 'cursorError'
   | 'resync'
   | 'schemaChange'


### PR DESCRIPTION
This is a step towards consolidating the retry logic across mongo2elastic, mongo2crate and mongo2mongo.

mongo2elastic and mongo2mongo currently do not have retries, whereas mongo2crate has retries baked into its query functions. All 3 libraries have a try/catch where they emit an "error" event. In order to consolidate this and ensure that only one "error" event is emitted once all retries are exhausted, I think we need to move the try/catch and emission of the "error" event into mongochangestream.