### PR TITLE
Update `mongochangestream-testing` 0.1.0 => 0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,3 +227,21 @@ db.collection('someColl').replaceOne({_id: ObjectId(...)}, ..., {upsert: true})
 ```js
 db.collection('someColl').deleteOne({_id: ObjectId(...)})
 ```
+
+## Running tests
+
+There are tests in this repo that can be run with `npm test`. The tests require
+a running MongoDB instance and a running Redis instance.
+
+By default, the tests will attempt to connect to Mongo at `localhost:27017` and
+Redis at `localhost:6379`. You can override the Mongo connection string by
+setting the `MONGO_CONN` environment variable, e.g. in a `.env` file.
+
+> [!TIP]
+> Before running the tests, make sure you:
+>
+> - ...have Node version 22 or higher installed.
+> - ...have a MongoDB instance running and `MONGO_CONN` set to the connection
+>   string.
+> - ...have a Redis instance running on `localhost:6379`.
+> - ...are running `npm build:watch` to compile the TypeScript to JavaScript.

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "globals": "^15.14.0",
-        "mongochangestream-testing": "^0.1.0",
+        "mongochangestream-testing": "^0.4.0",
         "prettier": "^3.4.2",
         "typescript": "^5.7.2"
       },
@@ -2602,10 +2602,11 @@
       }
     },
     "node_modules/mongochangestream-testing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.1.0.tgz",
-      "integrity": "sha512-1H6dndz5y3ipP8vajJ3l3zEfEzb2r6+lh0qZhLHzq05a5m5YI5O9i+w6PFJy3uQ3yKLciAgpowR0Gb+YuHXzlw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
+      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
       "dev": true,
+      "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
         "mongodb": "^6.12.0"
@@ -5179,9 +5180,9 @@
       }
     },
     "mongochangestream-testing": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.1.0.tgz",
-      "integrity": "sha512-1H6dndz5y3ipP8vajJ3l3zEfEzb2r6+lh0qZhLHzq05a5m5YI5O9i+w6PFJy3uQ3yKLciAgpowR0Gb+YuHXzlw==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
+      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
       "dev": true,
       "requires": {
         "@faker-js/faker": "^9.3.0",

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "globals": "^15.14.0",
-    "mongochangestream-testing": "^0.1.0",
+    "mongochangestream-testing": "^0.4.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2"
   },

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -1,7 +1,3 @@
-/**
- * To run add a local .env file with MONGO_CONN and execute npm test.
- * NOTE: Node version 22 or higher is required.
- */
 import { Redis } from 'ioredis'
 import _ from 'lodash/fp.js'
 import { genUser, initState, numDocs, schema } from 'mongochangestream-testing'


### PR DESCRIPTION
I ran into a couple of hurdles trying to run the tests locally:

* Because my Mongo database didn't have a `testing` collection yet, the tests were throwing a "namespace not found" error. I noticed that the latest `mongochangestream-testing` creates the collection for you, so I tried updating to that version and it fixed that issue.
* I didn't have Redis running, so the tests were throwing an error. Starting Redis fixed it.

I also updated the README to make the steps to run the tests clearer.