### PR TITLE
Update resume token when the end of the change stream is reached

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+# 0.59.0
+
+- The resume token stored in Redis is now updated regularly, even if the
+  collection has not been updated in a long time. This enables mongochangestream
+  to work in cases where older entries in the oplog (including the previously
+  stored, old resume token) have been truncated, and generally improves
+  performance because there are less oplog records to scan through.
+
+- Removed `hasNext`. It turns out that it blocks forever once you reach the end
+  of the change stream. It's better to use `getNext` and check whether the
+  result is null. When the end of the change stream is reached, `getNext` will
+  block for a minute or so and then return null.
+
 # 0.58.0
 
 - Wrap retry in try/catch and emit `processError` on exception.

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -401,6 +401,7 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       debug('Change stream pipeline %O', pipeline)
       // Lookup change stream token
       const token = await redis.get(keys.changeStreamTokenKey)
+      debug('Last recorded resume token: %O', token)
       const changeStreamOptions: mongodb.ChangeStreamOptions = token
         ? // Resume token found, so set change stream resume point
           { ...defaultOptions, resumeAfter: JSON.parse(token) }
@@ -422,27 +423,38 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       }
       state.change('starting')
 
-      const _processRecords = async (records: ChangeStreamDocument[]) => {
-        const numRecords = records.length
-        const token = records[numRecords - 1]._id
+      changeStream = await getChangeStream()
+      debug('Started change stream')
+
+      const _processRecords = async (
+        maybeRecords: (ChangeStreamDocument | null)[]
+      ) => {
+        // Each item in `maybeRecords` is either an actual record, or null. The
+        // last item in the array can be null, which is a signal that we have
+        // reached the end of the change stream and we just need to update the
+        // resume token in Redis.
+        const records = maybeRecords.filter((record) => record != null)
+
         // Process batch of records with retries.
         // NOTE: processRecords could mutate records.
         try {
-          await retry(() => processRecords(records), {
-            ...retryOptions,
-            signal: retryController.signal,
-          })
-          debug('Processed %d records', numRecords)
-          debug('Token %s', token)
-          if (token) {
-            // Persist state
-            await redis.mset(
-              keys.changeStreamTokenKey,
-              JSON.stringify(token),
-              keys.lastChangeProcessedAtKey,
-              new Date().getTime()
-            )
+          if (records.length > 0) {
+            await retry(() => processRecords(records), {
+              ...retryOptions,
+              signal: retryController.signal,
+            })
+            debug('Processed %d records', records.length)
           }
+
+          // Persist state
+          const token = changeStream.resumeToken
+          debug('Updating resume token to: %s', token)
+          await redis.mset(
+            keys.changeStreamTokenKey,
+            JSON.stringify(token),
+            keys.lastChangeProcessedAtKey,
+            new Date().getTime()
+          )
         } catch (error) {
           debug('Process error %o', error)
           if (!state.is('stopping')) {
@@ -463,37 +475,57 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
         timeout: ms('30s'),
         ...options,
       })
-      // Start the change stream
-      changeStream = await getChangeStream()
+
       const nextChecker = safelyCheckNext(changeStream)
       state.change('started')
-      let event: ChangeStreamDocument | null
-      // Consume change stream
-      while (await nextChecker.hasNext()) {
-        event = await changeStream.next()
-        debug('Change stream event %O', event)
-        // Omit nested fields that are not handled by $unset.
-        // For example, if 'a' was omitted then 'a.b.c' should be omitted.
-        if (
-          omit &&
-          event.operationType === 'update' &&
-          // Downstream libraries might unset event.updateDescription
-          // to optimize performance (e.g., mongo2elastic).
-          event.updateDescription
-        ) {
-          omitFieldsForUpdate(omit, event)
+
+      // Consume change stream until there is an error or `stop` is called.
+      while (!state.is('stopping')) {
+        // This always updates `changeStream.resumeToken`, even when we reach
+        // the end of the change stream and null is returned.
+        //
+        // This is important because we always want to keep a recent resume
+        // token. Attempting to resume from an older resume token might not
+        // work, because only a certain (configurable) amount of oplog history
+        // is kept. Even if the oplog entry still exists, it can take a very
+        // long time to scan through all of the oplog entries since then, so
+        // keeping a recent resume token is vital for performance.
+        const event: ChangeStreamDocument | null = await nextChecker.getNext()
+
+        if (event) {
+          debug('Change stream event %O', event)
+          // Omit nested fields that are not handled by $unset.
+          // For example, if 'a' was omitted then 'a.b.c' should be omitted.
+          if (
+            omit &&
+            event.operationType === 'update' &&
+            // Downstream libraries might unset event.updateDescription
+            // to optimize performance (e.g., mongo2elastic).
+            event.updateDescription
+          ) {
+            omitFieldsForUpdate(omit, event)
+          }
         }
+
         await queue.enqueue(event)
         await pause.maybeBlock()
+
+        if (!event) {
+          // The null event (i.e. "end of change stream") is always the last
+          // event in the batch. See `_processRecords`.
+          await queue.flush()
+        }
+
+        if (nextChecker.errorExists() && !state.is('stopping')) {
+          emit('cursorError', {
+            name: 'processChangeStream',
+            error: nextChecker.getLastError(),
+          } as CursorErrorEvent)
+          break
+        }
       }
-      await queue.flush()
-      // An error occurred getting next and we are not stopping
-      if (nextChecker.errorExists() && !state.is('stopping')) {
-        emit('cursorError', {
-          name: 'processChangeStream',
-          error: nextChecker.getLastError(),
-        } as CursorErrorEvent)
-      }
+
+      // Signal stopping => stopped state change
       deferred.done()
       debug('Exit change stream')
     }


### PR DESCRIPTION
We've been having an issue where, if a collection hasn't been updated in a long time, the change stream aggregation can take many minutes to complete. With help from Mongo support, we determined the issue to be that we are continuously trying to resume the change stream from the same old resume token, whose timestamp matches up with the last updated record.

I confirmed that when you call `changeStream.tryNext()` and there are no further updates (i.e. you've reached the "end" of the change stream), after a small pause, `tryNext` will return null, but then after that, `changeStream.resumeToken` is a more recent "no-op" event with a fresh timestamp.

This PR makes some small adjustments so that we will always use the latest `changeStream.resumeToken`, even in the scenario where the collection has not been updated in a long time and there are no more updates to process.

I tested this with a little script I wrote that uses mongochangestream to watch a collection and simply print the change stream events. With the changes on this branch in place, I was able to confirm that we're getting a new resume token in this scenario. I also used the `decodeResumeToken` in `mongosh` to decode the resume tokens and check the timestamps.

I also ran the unit tests many times and confirmed that they're all passing. I added a test case that tests that the resume token is updated as expected.