### PR TITLE
Use `assertEventually` from latest `mongochangestream-testing`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.58.0",
+  "version": "0.59.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.58.0",
+      "version": "0.59.0",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",
@@ -27,7 +27,7 @@
         "@types/node": "^22.10.2",
         "@typescript-eslint/eslint-plugin": "^8.19.0",
         "globals": "^15.14.0",
-        "mongochangestream-testing": "^0.4.0",
+        "mongochangestream-testing": "^0.5.0",
         "prettier": "^3.4.2",
         "typescript": "^5.7.2",
         "vitest": "^3.0.6"
@@ -2720,14 +2720,15 @@
       }
     },
     "node_modules/mongochangestream-testing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
-      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "node_modules/mongodb": {
@@ -5568,13 +5569,14 @@
       }
     },
     "mongochangestream-testing": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.4.0.tgz",
-      "integrity": "sha512-qVcdCoeSyu7eiQzhwmrQz32WZ4Cy9oTV2LXxD6fOWuqPcO7aV+/tnY7C6ZH4rInp1ueMsgWQOxf3jdLkbFyscw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/mongochangestream-testing/-/mongochangestream-testing-0.5.0.tgz",
+      "integrity": "sha512-n2hNIs4NG9rmne7v30cPzVIhb7P2xI0o/6fVc7qlWJtBb7j94CQZJylx+w5FzJs1BeHtONsypnDatSGuzwSKYg==",
       "dev": true,
       "requires": {
         "@faker-js/faker": "^9.3.0",
-        "mongodb": "^6.12.0"
+        "mongodb": "^6.12.0",
+        "prom-utils": "^0.14.0"
       }
     },
     "mongodb": {

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@types/node": "^22.10.2",
     "@typescript-eslint/eslint-plugin": "^8.19.0",
     "globals": "^15.14.0",
-    "mongochangestream-testing": "^0.4.0",
+    "mongochangestream-testing": "^0.5.0",
     "prettier": "^3.4.2",
     "typescript": "^5.7.2",
     "vitest": "^3.0.6"

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -1,6 +1,12 @@
 import { Redis } from 'ioredis'
 import _ from 'lodash/fp.js'
-import { genUser, initState, numDocs, schema } from 'mongochangestream-testing'
+import {
+  assertEventually,
+  genUser,
+  initState,
+  numDocs,
+  schema,
+} from 'mongochangestream-testing'
 import {
   type ChangeStreamDocument,
   type ChangeStreamInsertDocument,
@@ -11,13 +17,7 @@ import {
 import ms from 'ms'
 import assert from 'node:assert'
 import { setTimeout } from 'node:timers/promises'
-import {
-  type LastFlush,
-  type QueueOptions,
-  type QueueStats,
-  TimeoutError,
-  waitUntil,
-} from 'prom-utils'
+import { type LastFlush, type QueueOptions, type QueueStats } from 'prom-utils'
 import { describe, test } from 'vitest'
 
 import { getKeys, initSync } from './mongoChangeStream.js'
@@ -46,31 +46,6 @@ const getSync = async (options?: SyncOptions) => {
   const sync = initSync(redis, coll, options)
   sync.emitter.on('stateChange', console.log)
   return sync
-}
-
-/**
- * Asserts that the provided predicate eventually returns true.
- *
- * @param pred - The predicate to check: an async function returning a boolean.
- * @param failureMessage - The message to display if the predicate does not
- * return true before the timeout.
- *
- * @throws AssertionError if the predicate does not return true before the
- * timeout.
- */
-const assertEventually = async (
-  pred: () => Promise<boolean>,
-  failureMessage = 'Failed to satisfy predicate'
-) => {
-  try {
-    await waitUntil(pred, { timeout: ms('20s'), checkFrequency: ms('50ms') })
-  } catch (e) {
-    if (e instanceof TimeoutError) {
-      assert.fail(failureMessage)
-    } else {
-      throw e
-    }
-  }
 }
 
 describe.sequential('syncing', () => {
@@ -1286,10 +1261,7 @@ describe.sequential('syncing', () => {
 
     // Waiting for a while after an update should result in the resume token
     // updating again.
-    await assertResumeTokenUpdated(
-      token,
-      'after waiting again after an update'
-    )
+    await assertResumeTokenUpdated(token, 'after waiting again after an update')
 
     await changeStream.stop()
   })


### PR DESCRIPTION
Just a little cleanup related to the most recent changes. `assertEventually` is now part of the `mongochangestream-testing` library, so we can pull it in from there instead of having a copy of it in this repo.