### PR TITLE
Better type handling for `processChangeStream` callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.60.0
+
+- Type narrowing for `processChangeStream` based on `options.operationTypes`.
+
 # 0.59.0
 
 - The resume token stored in Redis is now updated regularly, even if the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.59.0",
+  "version": "0.60.0",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -942,17 +942,20 @@ describe.sequential('syncing', () => {
     await initState(sync, db, coll)
 
     const operations: string[] = []
-    const processRecords = async (docs: ChangeStreamDocument[]) => {
-      for (const doc of docs) {
-        await setTimeout(5)
-        operations.push(doc.operationType)
+
+    const changeStream = await sync.processChangeStream(
+      async (docs) => {
+        for (const doc of docs) {
+          await setTimeout(5)
+          operations.push(doc.operationType)
+        }
+      },
+      {
+        operationTypes: ['insert'],
+        // Short timeout since only event will be queued
+        timeout: 500,
       }
-    }
-    const changeStream = await sync.processChangeStream(processRecords, {
-      operationTypes: ['insert'],
-      // Short timeout since only event will be queued
-      timeout: 500,
-    })
+    )
     // Start
     changeStream.start()
     await setTimeout(ms('1s'))
@@ -1286,10 +1289,7 @@ describe.sequential('syncing', () => {
 
     // Waiting for a while after an update should result in the resume token
     // updating again.
-    await assertResumeTokenUpdated(
-      token,
-      'after waiting again after an update'
-    )
+    await assertResumeTokenUpdated(token, 'after waiting again after an update')
 
     await changeStream.stop()
   })

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -556,15 +556,17 @@ describe.sequential('syncing', () => {
       cursorError = true
     })
     const processed: unknown[] = []
-    const processRecords = async (docs: ChangeStreamDocument[]) => {
-      for (const doc of docs) {
-        await setTimeout(5)
-        // Simulate downstream mutation
-        delete doc._id
-        processed.push(doc)
+    const changeStream = await sync.processChangeStream(
+      // Type for docs is ChangeStreamDocument[]
+      async (docs) => {
+        for (const doc of docs) {
+          await setTimeout(5)
+          // Simulate downstream mutation
+          delete doc._id
+          processed.push(doc)
+        }
       }
-    }
-    const changeStream = await sync.processChangeStream(processRecords)
+    )
     // Start
     changeStream.start()
     await setTimeout(ms('1s'))

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -944,6 +944,7 @@ describe.sequential('syncing', () => {
     const operations: string[] = []
 
     const changeStream = await sync.processChangeStream(
+      // Type for docs is ChangeStreamInsertDocument[]
       async (docs) => {
         for (const doc of docs) {
           await setTimeout(5)

--- a/src/types.ts
+++ b/src/types.ts
@@ -113,8 +113,6 @@ export interface ChangeStreamOptions<
 export interface ChangeOptions {
   /** How often to retrieve the schema and look for a change. */
   interval?: number
-  /** @deprecated Use shouldRemoveUnusedFields instead.*/
-  shouldRemoveMetadata?: boolean
   /**
    * Remove fields that are not used when converting the schema
    * in a downstream library like mongo2elastic or mongo2crate.

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,7 +35,7 @@ type OperationTypeMap = {
 }
 
 /**
- * Union of all possible operation types. For example, 'insert' | 'update' | 'delete'.
+ * Union of all possible operation types - 'insert' | 'update' | 'delete' etc.
  */
 export type OperationType = keyof OperationTypeMap
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,12 +15,18 @@ export type JSONSchema = Record<string, any>
 
 type MaybePromise<T> = T | Promise<T>
 
-/** Utility type to extract the operationType from a document type */
+/**
+ * Extract the operationType field from a type.
+ * Create a union of all possible operation types.
+ */
 type ExtractOperationType<T> = T extends { operationType: infer Type }
   ? Type
   : never
 
-/** Mapping from operation type to document type */
+/**
+ * Mapping from operation type to document type. For example, if the operation
+ * type is 'insert', the document type is ChangeStreamInsertDocument.
+ */
 type OperationTypeMap = {
   [K in ExtractOperationType<ChangeStreamDocument>]: Extract<
     ChangeStreamDocument,
@@ -28,9 +34,16 @@ type OperationTypeMap = {
   >
 }
 
+/**
+ * Union of all possible operation types. For example, 'insert' | 'update' | 'delete'.
+ */
 export type OperationType = keyof OperationTypeMap
 
-/** Extract the specific document types from an array of operation types */
+/**
+ * Extract the specific document types from an array of operation types.
+ * For example, if the type parameter is ['insert', 'update'], the return type
+ * is ChangeStreamInsertDocument | ChangeStreamUpdateDocument.
+ */
 export type DocumentsForOperationTypes<T extends OperationType[] | undefined> =
   T extends OperationType[] ? OperationTypeMap[T[number]] : ChangeStreamDocument
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,22 @@
 import type {
   AggregationCursor,
   ChangeStream,
+  ChangeStreamCollModDocument,
+  ChangeStreamCreateDocument,
+  ChangeStreamCreateIndexDocument,
+  ChangeStreamDeleteDocument,
   ChangeStreamDocument,
+  ChangeStreamDropDatabaseDocument,
+  ChangeStreamDropDocument,
+  ChangeStreamDropIndexDocument,
   ChangeStreamInsertDocument,
+  ChangeStreamInvalidateDocument,
+  ChangeStreamRefineCollectionShardKeyDocument,
+  ChangeStreamRenameDocument,
+  ChangeStreamReplaceDocument,
+  ChangeStreamReshardCollectionDocument,
+  ChangeStreamShardCollectionDocument,
+  ChangeStreamUpdateDocument,
   Document,
   MongoAPIError,
   MongoServerError,
@@ -15,9 +29,35 @@ export type JSONSchema = Record<string, any>
 
 type MaybePromise<T> = T | Promise<T>
 
-export type ProcessChangeStreamRecords = (
-  docs: ChangeStreamDocument[]
-) => MaybePromise<void>
+// Create a mapped type for operation types
+type OperationTypeMap = {
+  insert: ChangeStreamInsertDocument
+  update: ChangeStreamUpdateDocument
+  replace: ChangeStreamReplaceDocument
+  delete: ChangeStreamDeleteDocument
+  drop: ChangeStreamDropDocument
+  rename: ChangeStreamRenameDocument
+  dropDatabase: ChangeStreamDropDatabaseDocument
+  invalidate: ChangeStreamInvalidateDocument
+  createIndex: ChangeStreamCreateIndexDocument
+  create: ChangeStreamCreateDocument
+  collMod: ChangeStreamCollModDocument
+  dropIndex: ChangeStreamDropIndexDocument
+  shardCollection: ChangeStreamShardCollectionDocument
+  reshardCollection: ChangeStreamReshardCollectionDocument
+  refineCollectionShardKey: ChangeStreamRefineCollectionShardKeyDocument
+}
+
+// Create a type for the valid operation types
+export type OperationType = keyof OperationTypeMap
+
+// Type to extract the specific document types from an array of operation types
+export type DocumentsForOperationTypes<T extends OperationType[] | undefined> =
+  T extends OperationType[] ? OperationTypeMap[T[number]] : ChangeStreamDocument
+
+export type ProcessChangeStreamRecords<
+  T extends OperationType[] | undefined = undefined,
+> = (docs: DocumentsForOperationTypes<T>[]) => MaybePromise<void>
 
 export type ProcessInitialScanRecords = (
   docs: ChangeStreamInsertDocument[]
@@ -64,9 +104,11 @@ export interface ScanOptions<T = any> {
   pipeline?: Document[]
 }
 
-export interface ChangeStreamOptions {
+export interface ChangeStreamOptions<
+  T extends OperationType[] | undefined = undefined,
+> {
   pipeline?: Document[]
-  operationTypes?: ChangeStreamDocument['operationType'][]
+  operationTypes?: T
 }
 
 export interface ChangeOptions {

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,21 +31,21 @@ type MaybePromise<T> = T | Promise<T>
 
 /** Mapped type for operation types */
 type OperationTypeMap = {
-  insert: ChangeStreamInsertDocument
-  update: ChangeStreamUpdateDocument
-  replace: ChangeStreamReplaceDocument
+  create: ChangeStreamCreateDocument
+  createIndexes: ChangeStreamCreateIndexDocument
   delete: ChangeStreamDeleteDocument
   drop: ChangeStreamDropDocument
-  rename: ChangeStreamRenameDocument
   dropDatabase: ChangeStreamDropDatabaseDocument
+  dropIndexes: ChangeStreamDropIndexDocument
+  insert: ChangeStreamInsertDocument
   invalidate: ChangeStreamInvalidateDocument
-  createIndex: ChangeStreamCreateIndexDocument
-  create: ChangeStreamCreateDocument
-  collMod: ChangeStreamCollModDocument
-  dropIndex: ChangeStreamDropIndexDocument
-  shardCollection: ChangeStreamShardCollectionDocument
-  reshardCollection: ChangeStreamReshardCollectionDocument
+  modify: ChangeStreamCollModDocument
   refineCollectionShardKey: ChangeStreamRefineCollectionShardKeyDocument
+  rename: ChangeStreamRenameDocument
+  replace: ChangeStreamReplaceDocument
+  reshardCollection: ChangeStreamReshardCollectionDocument
+  shardCollection: ChangeStreamShardCollectionDocument
+  update: ChangeStreamUpdateDocument
 }
 
 export type OperationType = keyof OperationTypeMap

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,7 +16,9 @@ export type JSONSchema = Record<string, any>
 type MaybePromise<T> = T | Promise<T>
 
 /** Utility type to extract the operationType from a document type */
-type ExtractOperationType<T> = T extends { operationType: infer O } ? O : never
+type ExtractOperationType<T> = T extends { operationType: infer Type }
+  ? Type
+  : never
 
 /** Mapping from operation type to document type */
 type OperationTypeMap = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -29,7 +29,7 @@ export type JSONSchema = Record<string, any>
 
 type MaybePromise<T> = T | Promise<T>
 
-// Create a mapped type for operation types
+/** Mapped type for operation types */
 type OperationTypeMap = {
   insert: ChangeStreamInsertDocument
   update: ChangeStreamUpdateDocument
@@ -48,10 +48,9 @@ type OperationTypeMap = {
   refineCollectionShardKey: ChangeStreamRefineCollectionShardKeyDocument
 }
 
-// Create a type for the valid operation types
 export type OperationType = keyof OperationTypeMap
 
-// Type to extract the specific document types from an array of operation types
+/** Extract the specific document types from an array of operation types */
 export type DocumentsForOperationTypes<T extends OperationType[] | undefined> =
   T extends OperationType[] ? OperationTypeMap[T[number]] : ChangeStreamDocument
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,22 +1,8 @@
 import type {
   AggregationCursor,
   ChangeStream,
-  ChangeStreamCollModDocument,
-  ChangeStreamCreateDocument,
-  ChangeStreamCreateIndexDocument,
-  ChangeStreamDeleteDocument,
   ChangeStreamDocument,
-  ChangeStreamDropDatabaseDocument,
-  ChangeStreamDropDocument,
-  ChangeStreamDropIndexDocument,
   ChangeStreamInsertDocument,
-  ChangeStreamInvalidateDocument,
-  ChangeStreamRefineCollectionShardKeyDocument,
-  ChangeStreamRenameDocument,
-  ChangeStreamReplaceDocument,
-  ChangeStreamReshardCollectionDocument,
-  ChangeStreamShardCollectionDocument,
-  ChangeStreamUpdateDocument,
   Document,
   MongoAPIError,
   MongoServerError,
@@ -29,23 +15,15 @@ export type JSONSchema = Record<string, any>
 
 type MaybePromise<T> = T | Promise<T>
 
-/** Mapped type for operation types */
+/** Utility type to extract the operationType from a document type */
+type ExtractOperationType<T> = T extends { operationType: infer O } ? O : never
+
+/** Mapping from operation type to document type */
 type OperationTypeMap = {
-  create: ChangeStreamCreateDocument
-  createIndexes: ChangeStreamCreateIndexDocument
-  delete: ChangeStreamDeleteDocument
-  drop: ChangeStreamDropDocument
-  dropDatabase: ChangeStreamDropDatabaseDocument
-  dropIndexes: ChangeStreamDropIndexDocument
-  insert: ChangeStreamInsertDocument
-  invalidate: ChangeStreamInvalidateDocument
-  modify: ChangeStreamCollModDocument
-  refineCollectionShardKey: ChangeStreamRefineCollectionShardKeyDocument
-  rename: ChangeStreamRenameDocument
-  replace: ChangeStreamReplaceDocument
-  reshardCollection: ChangeStreamReshardCollectionDocument
-  shardCollection: ChangeStreamShardCollectionDocument
-  update: ChangeStreamUpdateDocument
+  [K in ExtractOperationType<ChangeStreamDocument>]: Extract<
+    ChangeStreamDocument,
+    { operationType: K }
+  >
 }
 
 export type OperationType = keyof OperationTypeMap


### PR DESCRIPTION
### Changes

- Type narrowing for `processChangeStream` based on `options.operationTypes`. Claude FTW!

### Explanation of what's going on

1. `ExtractOperationType` Utility Type

```ts
type ExtractOperationType<T> = T extends { operationType: infer Type } ? Type : never;
```
This is a conditional type that:

Takes a generic type parameter T
Checks if T has a property called operationType using the extends keyword
If it does, it uses the infer keyword to extract the type of that property and calls it Type
Returns that inferred type Type
If T doesn't have an operationType property, returns never (a type that can't be assigned any value)

When we apply this to ChangeStreamDocument:
```ts
type AllOperationTypes = ExtractOperationType<ChangeStreamDocument>;
```
It extracts a union of all possible values for the operationType property, which would be:
'insert' | 'update' | 'replace' | 'delete' | 'drop' | 'rename' | 'dropDatabase' | 'invalidate' | ...

2. Creating the `OperationTypeMap`

```ts
type OperationTypeMap = {
  [K in ExtractOperationType<ChangeStreamDocument>]: Extract<ChangeStreamDocument, { operationType: K }>
}
```

This uses a mapped type to:

Iterate over each possible operation type (K) extracted from ChangeStreamDocument
For each operation type, it creates a property with that name
The value of each property is determined by Extract<ChangeStreamDocument, { operationType: K }>

The Extract utility type filters the ChangeStreamDocument union to only keep types where the operationType property equals K. For example:

When K is 'insert', it keeps only ChangeStreamInsertDocument
When K is 'update', it keeps only ChangeStreamUpdateDocument

So the resulting `OperationTypeMap` has this structure:

```ts
{
  'insert': ChangeStreamInsertDocument,
  'update': ChangeStreamUpdateDocument,
  'replace': ChangeStreamReplaceDocument,
  // ... and so on for all operation types
}
```

3. Creating the `OperationType` Type

```ts
type OperationType = keyof OperationTypeMap;
```

This simply takes all the keys from OperationTypeMap, giving us a union of all possible operation types. This is equivalent to ExtractOperationType<ChangeStreamDocument>, but it's defined in terms of OperationTypeMap to keep the types connected.

4. The `DocumentsForOperationTypes` Type

```ts
type DocumentsForOperationTypes<T extends OperationType[] | undefined> = 
  T extends OperationType[] 
    ? OperationTypeMap[T[number]] 
    : ChangeStreamDocument;
```    
    
This is a conditional type that:

Takes a generic type parameter T that must be either an array of operation types or undefined
If T is an array of operation types, it:

Uses T[number] to get a union of all types in the array
Uses that union to index into OperationTypeMap to get the corresponding document types


If T is undefined, it returns the full ChangeStreamDocument union

For example:

If T is ['insert', 'update']
Then T[number] is 'insert' | 'update'
Then OperationTypeMap[T[number]] is OperationTypeMap['insert'] | OperationTypeMap['update']
Which resolves to ChangeStreamInsertDocument | ChangeStreamUpdateDocument

Usage Example
When you use this in processChangeStream:

```ts
const processChangeStream = async 
  T extends OperationType[] | undefined = undefined,
>(
  processRecords: ProcessChangeStreamRecords<T>,
  options: QueueOptions & ChangeStreamOptions<T> = {}
) => {
  // ...
  
  const event: DocumentsForOperationTypes<T> | null = await nextChecker.getNext();
  
  // ...
}
```

If you call it with specific operation types:

```ts
processChangeStream(
  (docs) => { /* ... */ },
  { operationTypes: ['insert', 'update'] }
)
```

The type system will automatically ensure that:

`docs` in your callback will be of type `(ChangeStreamInsertDocument | ChangeStreamUpdateDocument)[]`
`event` in the implementation will be of type `ChangeStreamInsertDocument | ChangeStreamUpdateDocument | null`

This gives you precise type safety throughout the system, with the types being derived directly from the MongoDB type definitions.