### PR TITLE
Bug fix: Unpause when calling `stop` for `processChangeStream` or  `runInitialScan` to prevent hanging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 0.61.1
+
+- Bug fix: Unpause when calling `stop` for `processChangeStream` or `runInitialScan` to prevent hanging.
+
 # 0.61.0
 
 - Bump dependencies to fix security vulnerabilities.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mongochangestream",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "mongochangestream",
-      "version": "0.61.0",
+      "version": "0.61.1",
       "license": "ISC",
       "dependencies": {
         "debug": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mongochangestream",
-  "version": "0.61.0",
+  "version": "0.61.1",
   "description": "Sync MongoDB collections via change streams into any database.",
   "author": "GovSpend",
   "main": "dist/index.js",

--- a/src/mongoChangeStream.test.ts
+++ b/src/mongoChangeStream.test.ts
@@ -115,7 +115,7 @@ describe.sequential('syncing', () => {
     await initialScan.stop()
   })
 
-  //------- Initial scan -------
+  //------- Initial Scan -------
   test('should complete initial scan', async () => {
     const { coll, db, redis } = await getConns()
     const sync = await getSync()
@@ -542,7 +542,7 @@ describe.sequential('syncing', () => {
     assert.ok(documents[0].cityState)
   })
 
-  //------- Change stream -------
+  //------- Change Stream -------
   test('should process records via change stream', async () => {
     const { coll, db, redis } = await getConns()
     const sync = await getSync()
@@ -1103,6 +1103,58 @@ describe.sequential('syncing', () => {
     await changeStream.stop()
   })
 
+  test('should update the resume token, even if there were no records updated', async () => {
+    const { coll, db, redis } = await getConns()
+    const sync = await getSync()
+    await initState(sync, db, coll)
+    const processRecords = async () => {
+      await setTimeout(5)
+    }
+
+    // Utilities for comparing resume tokens to see if they change over time.
+    const { changeStreamTokenKey } = getKeys(coll, {})
+    const getCurrentToken = async () => await redis.get(changeStreamTokenKey)
+    const assertResumeTokenUpdated = async (
+      lastToken: string | null,
+      when: string
+    ): Promise<string | null> => {
+      let currentToken: string | null = null
+
+      await assertEventually(async () => {
+        currentToken = await getCurrentToken()
+        return currentToken !== lastToken
+      }, `Resume token was not updated ${when}`)
+
+      return currentToken
+    }
+
+    // The resume token should initially be null, since we ran `initState`
+    // above.
+    const token = await getCurrentToken()
+    assert.equal(token, null)
+
+    const changeStream = await sync.processChangeStream(processRecords, {
+      timeout: ms('5s'),
+    })
+    changeStream.start()
+    // Let change stream connect
+    await setTimeout(ms('1s'))
+
+    // Waiting for a while should result in an updated resume token.
+    await assertResumeTokenUpdated(token, 'after waiting')
+
+    // Updating records results in an updated resume token.
+    await coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
+    await assertResumeTokenUpdated(token, 'after updating records')
+
+    // Waiting for a while after an update should result in the resume token
+    // updating again.
+    await assertResumeTokenUpdated(token, 'after waiting again after an update')
+
+    await changeStream.stop()
+  })
+
+  // ------ Detect Resync -------
   test('Should resync when resync flag is set', async () => {
     const { coll, db, redis } = await getConns()
     const sync = await getSync()
@@ -1177,6 +1229,7 @@ describe.sequential('syncing', () => {
     resync.stop()
   })
 
+  //------ Detect Schema Change -------
   test('Detect schema change', async () => {
     const { db, coll } = await getConns()
     const sync = await getSync()
@@ -1251,6 +1304,7 @@ describe.sequential('syncing', () => {
     schemaChange.stop()
   })
 
+  //------ Events -------
   test('can extend events', async () => {
     const { coll, redis } = await getConns({})
     const sync = initSync<'foo' | 'bar'>(redis, coll)
@@ -1260,56 +1314,5 @@ describe.sequential('syncing', () => {
     })
     sync.emitter.emit('foo', 'bar')
     assert.strictEqual(emitted, 'bar')
-  })
-
-  test('should update the resume token, even if there were no records updated', async () => {
-    const { coll, db, redis } = await getConns()
-    const sync = await getSync()
-    await initState(sync, db, coll)
-    const processRecords = async () => {
-      await setTimeout(5)
-    }
-
-    // Utilities for comparing resume tokens to see if they change over time.
-    const { changeStreamTokenKey } = getKeys(coll, {})
-    const getCurrentToken = async () => await redis.get(changeStreamTokenKey)
-    const assertResumeTokenUpdated = async (
-      lastToken: string | null,
-      when: string
-    ): Promise<string | null> => {
-      let currentToken: string | null = null
-
-      await assertEventually(async () => {
-        currentToken = await getCurrentToken()
-        return currentToken !== lastToken
-      }, `Resume token was not updated ${when}`)
-
-      return currentToken
-    }
-
-    // The resume token should initially be null, since we ran `initState`
-    // above.
-    const token = await getCurrentToken()
-    assert.equal(token, null)
-
-    const changeStream = await sync.processChangeStream(processRecords, {
-      timeout: ms('5s'),
-    })
-    changeStream.start()
-    // Let change stream connect
-    await setTimeout(ms('1s'))
-
-    // Waiting for a while should result in an updated resume token.
-    await assertResumeTokenUpdated(token, 'after waiting')
-
-    // Updating records results in an updated resume token.
-    await coll.updateMany({}, { $set: { createdAt: new Date('2022-01-03') } })
-    await assertResumeTokenUpdated(token, 'after updating records')
-
-    // Waiting for a while after an update should result in the resume token
-    // updating again.
-    await assertResumeTokenUpdated(token, 'after waiting again after an update')
-
-    await changeStream.stop()
   })
 })

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -687,7 +687,11 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
     detectResync,
     keys,
     emitter,
-    /** Pause and resume all syncing functions at once. */
+    /**
+     * Pause and resume all syncing functions at once. A call to `stop`
+     * for `runInitialScan` or `processChangeStream` will resume to prevent
+     * hanging.
+     */
     pausable: pause,
   }
 }

--- a/src/mongoChangeStream.ts
+++ b/src/mongoChangeStream.ts
@@ -346,6 +346,9 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       // Abort retries
       retryController.abort('stopping')
       debug('Retry controller aborted')
+      // Unpause
+      pause.resume()
+      debug('Unpaused')
       // Wait for start fn to finish
       await deferred?.promise
       state.change('stopped')
@@ -552,6 +555,9 @@ export function initSync<ExtendedEvents extends EventEmitter.ValidEventTypes>(
       // Abort retries
       retryController.abort('stopping')
       debug('Retry controller aborted')
+      // Unpause
+      pause.resume()
+      debug('Unpaused')
       // Wait for start fn to finish
       await deferred?.promise
       state.change('stopped')


### PR DESCRIPTION
- Unpause when calling `stop` for `processChangeStream` or  `runInitialScan` to prevent hanging.
- Organized tests a little better.